### PR TITLE
Метод SimpleBLE::Peripheral может попытаться вернуть двоичные данные.…

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,10 @@ PYBIND11_MODULE(simplepyble, m) {
                  }
                  return ret;
              })
-        .def("read", &SimpleBLE::Peripheral::read)
+        .def("read", 
+             [](SimpleBLE::Peripheral& p, std::string const& service, std::string const& characteristic) {
+                 return py::bytes(p.read(service, characteristic));
+             })
         .def("write_request", [](SimpleBLE::Peripheral& p, std::string service, std::string characteristic,
                                  py::bytes payload) { p.write_request(service, characteristic, payload); })
         .def("write_command", [](SimpleBLE::Peripheral& p, std::string service, std::string characteristic,


### PR DESCRIPTION
As a solution to this issue: https://github.com/OpenBluetoothToolbox/python_simpleble/issues/9